### PR TITLE
Release 2.0.1

### DIFF
--- a/classes/completion/chat.php
+++ b/classes/completion/chat.php
@@ -93,9 +93,16 @@ class chat extends \block_openai_chat\completion {
         $response = $curl->post("https://api.openai.com/v1/chat/completions", json_encode($curlbody));
         $response = json_decode($response);
 
+        $message = null;
+        if (property_exists($response, 'error')) {
+            $message = 'ERROR: ' . $response->error->message;
+        } else {
+            $message = $response->choices[0]->message->content;
+        }
+
         return [
-            "id" => $response->id,
-            "message" => $response->choices[0]->message->content
+            "id" => property_exists($response, 'id') ? $response->id : 'error',
+            "message" => $message
         ];
     }
 }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'block_openai_chat';
-$plugin->version = 2024010300;
+$plugin->version = 2024012300;
 $plugin->requires = 2022041600;
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '2.0.0';
+$plugin->release = '2.0.1';


### PR DESCRIPTION
- Fix an issue where, if an API request generates an error on the OpenAI side, the chat window would display a blank message. Instead, the error will be printed in the chat.